### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Twitch Plays X#
+# Twitch Plays X #
 
 (inspired by [TwitchPlaysPokemon])
 
@@ -8,7 +8,7 @@ Tested on Windows 8, Ubuntu 13.10. Should work on a Mac as well - just change th
 
 > on Windows, the program has to be focused in order to send keyboard inputs so you won't be able to use your computer at the same time unless you run the program in a virtual machine.
 
-###In Action###
+### In Action ###
 ![](http://zippy.gfycat.com/ActiveLankyHorsemouse.gif)
 
 ![](http://zippy.gfycat.com/PoorDirectHuemul.gif)
@@ -17,14 +17,14 @@ Pokemon Red running in a Ubuntu 13.10 VM
 
 ![](http://i.imgur.com/aLSO6MK.gif)
 
-####Misc####
+#### Misc ####
 *https://github.com/hzoo/ChatPlays/ used MutationObservers in the browser*
 
 Using IRC lets you get all the messages; you can't always get all messages through the browser (quickly or consistently) so this is a better approach overall as others have done.
 
 Installation (node, etc)
 --------------
-###If Linux###
+### If Linux ###
 ```sh
 # node.js: can use nvm, apt-get, the ppa below, or https://nodejs.org/download/
 sudo apt-get update
@@ -41,7 +41,7 @@ npm install
 apt-get install xdotool
 ```
 
-###If Windows###
+### If Windows ###
 - Install [node.js] and npm
 - Download/clone files to computer - https://github.com/hzoo/TwitchPlaysX/archive/master.zip
 - Install node packages from command line `npm install` in folder (irc, printf)
@@ -52,7 +52,7 @@ apt-get install xdotool
 Setup
 --------------
 
-###Create config.json###
+### Create config.json ###
 - CONFIG_PROGRAM_NAME: Find out the title of the window
     - Ex: VisualBoyAdvance, Desmume
       - for notepad.exe it would be "Notepad" or "Untitled - Notepad"
@@ -80,20 +80,20 @@ More explanations of the config options in the [config.js](/app/config.js) file
 }
 ```
 
-##Running It!##
+## Running It! ##
 
-###Setup Program###
+### Setup Program ###
 - **Open program** to send keys to (VisualBoyAdvance, Desmume)
 - Optionally, change the controls (in the program itself, `defaultKeyMap` in keyHandler.js, keys.py for windows)
 - Optionally, find the option to allow program to receive background inputs (linux)
 
-###Run Server###
+### Run Server ###
 ```sh
 # go to the root folder, make sure you did `npm install`, then
 npm start
 ```
 
-##Method##
+## Method ##
 - Connect to IRC
 - Use regex to match for certain commands
   - print out username/message


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
