### PR TITLE
use pydirectinput to send keystrokes rather than win32api’s keybd_event

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On Windows, the program has to be *focused* in order to send keyboard inputs so 
 - Clone the repo: `git clone https://github.com/hzoo/TwitchPlaysX.git`
 - Install `node_modules` in the created folder: `npm install`
 - If Linux: install [xdotool](http://www.semicomplete.com/projects/xdotool/): `apt-get install xdotool`
-- If Windows: install [python] and [python win32] (with corresponding versions)
+- If Windows: install [python] and [python win32] (with corresponding versions), then install [pydirectinput](https://pypi.org/project/PyDirectInput/) with pip: `pip install pydirectinput`
 
 ## Setup
 

--- a/key.py
+++ b/key.py
@@ -2,31 +2,25 @@
 # http://stackoverflow.com/questions/1823762/sendkeys-for-python-3-1-on-windows
 # https://stackoverflow.com/a/38888131
 
-import win32api
 import win32con
 import win32gui
 import time, sys
+import pydirectinput
 
-keyDelay = 0.1
-# https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+# https://github.com/learncodebygaming/pydirectinput/blob/a585d044aed678576fefd24e7ad0c5945ab52366/pydirectinput/__init__.py#L48
+# The keys on the left are keys as defined in config.js, the keys on the right are the inputs to be sent
 keymap = {
-    "Up": win32con.VK_UP,
-    "Left": win32con.VK_LEFT,
-    "Down": win32con.VK_DOWN,
-    "Right": win32con.VK_RIGHT,
-    "b": 0x42, # ord("B"),
-    "a": 0x41, # ord("A"),
-    "y": 0x59, # ord("Y"),  # for DS
-    "x": 0x58, # ord("X"),  # for DS
-    "s": 0x53, # ord("S"),  # Start
-    "e": 0x45, # ord("E"),  # Select
+    "Up": 'up',
+    "Left": 'left',
+    "Down": 'down',
+    "Right": 'right',
+    "b": 'b',
+    "a": 'a',
+    "y": 'y', # for DS
+    "x": 'x', # for DS
+    "s": 's', # Start
+    "e": 'e', # Select
 }
-
-# this way has to keep window in focus
-def sendKey(button):
-    win32api.keybd_event(keymap[button], 0, 0, 0)
-    time.sleep(keyDelay)
-    win32api.keybd_event(keymap[button], 0, win32con.KEYEVENTF_KEYUP, 0)
 
 def SimpleWindowCheck(windowname):
     window = None
@@ -67,4 +61,6 @@ if __name__ == "__main__":
 
     win32gui.ShowWindow(winId, win32con.SW_SHOWNORMAL)
     win32gui.SetForegroundWindow(winId)
-    sendKey(key)
+		
+		# this way has to keep window in focus
+    pydirectinput.press(keymap[key])


### PR DESCRIPTION
Hello! I’m proposing this change because I was trying to use this with the BizHawk emulators but the keystrokes were getting ignored.

Turns out BizHawk reads key inputs at a driver level, and virtual keyboard events such as the ones sent by keybd_event from win32api will not work. This is the case for many games and programs. So I replaced this with [pydirectinput](https://pypi.org/project/PyDirectInput/) which sends keystrokes at a driver level.

Previous configurations with ordinal addresses would still work, but the library already has all addresses mapped, so they have more convenient shorthands (eg. just `'a'` instead of `0x41` or `ord("A")`)

The drawback to this is that the user has to install a third-party python library, but I think it’s worth it given that it gives TwitchPlaysX compatibility with virtually any game or program.

This should fix #15 and similar issues.